### PR TITLE
fix cfg guard so that cpio blob is included

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -40,9 +40,9 @@ fn expand_ramdisk() -> &'static [u8] {
     use miniz_oxide::inflate::core::DecompressorOxide;
     use miniz_oxide::inflate::TINFLStatus;
 
-    #[cfg(target_arch = "x86_64-oxide-none-elf")]
+    #[cfg(all(target_vendor = "oxide", target_os = "none"))]
     let cpio = include_bytes!(env!("PHBL_PHASE1_COMPRESSED_CPIO_ARCHIVE_PATH"));
-    #[cfg(not(target_arch = "x86_64-oxide-none-elf"))]
+    #[cfg(not(all(target_vendor = "oxide", target_os = "none")))]
     let cpio = [0u8; 1];
 
     let dst = phbl::ramdisk_region_init_mut();


### PR DESCRIPTION
The existing guard around including the cpio blob attempts to match on the target triple, but is using the "target_arch" attribute.  This attribute does not have the triple as the value, just "x86_64". Instead, we can use "target_os" and "target_vendor" to check for the standalone target we use when building the binary for inclusion in the ROM.