### PR TITLE
idt: rewrite GateDesc in terms of `bitstruct`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,6 +94,7 @@ checksum = "2f7254b99e31cad77da24b08ebf628882739a608578bb1bcdfc1f9c21260d7c0"
 name = "phbl"
 version = "0.1.0"
 dependencies = [
+ "bit_field",
  "bitstruct",
  "cpio_reader",
  "goblin",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ license = "MPL-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+bit_field = "0.10.1"
 bitstruct = "0.1"
 cpio_reader = "0.1"
 goblin = { version = "0.5", default-features = false, features = [


### PR DESCRIPTION
Rewrite `GateDesc` in terms of `bitstruct` to clarify it.

Fixes #6

Signed-off-by: Dan Cross <cross@oxidecomputer.com>