### PR TITLE
trivial: Clean up information some output

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -49,8 +49,8 @@ fn expand_ramdisk() -> &'static [u8] {
     let mut r = DecompressorOxide::new();
     let flags = TINFL_FLAG_PARSE_ZLIB_HEADER;
     print!(
-        "Decompressing cpio archive to {:#x?}..{:#x}...",
-        dst.as_ptr(),
+        "Decompressing cpio archive to {:#x}..{:#x}...",
+        dst.as_ptr() as usize,
         dst.len() + dst.as_ptr() as usize,
     );
     let (s, _, o) = decompress(&mut r, &cpio[..], dst, 0, flags);


### PR DESCRIPTION
On my most recent testing run, I noticed this output:

Decompressing cpio archive to 0x0000000077358000..0x7f358000...Done.

One may argue that the phrasing here could use improvement, perhaps rightfully so.  But notice the difference between the two numbers, and in particular the leading zeroes of the first and lack thereof in the second.  This is due to debug formatting of a pointer for the first, and a usize as the second.  While minor, I found this jarring; this PR cleans that up by formatting both as usize.

Signed-off-by: Dan Cross <cross@oxidecomputer.com>