### PR TITLE
memory: Convert `phbl` to use strict provenance

### DIFF
--- a/src/loader.rs
+++ b/src/loader.rs
@@ -125,7 +125,8 @@ fn load_segment(
             page_table
                 .map_region(region.clone(), mem::Attrs::new_data(), pa)
                 .expect("mapped region {region:#x?} read-write");
-            let p = start.addr() as *mut u8;
+            const NULL: *mut u8 = core::ptr::null_mut();
+            let p = NULL.with_addr(start.addr());
             let len = end.addr() - start.addr();
             core::ptr::write_bytes(p, 0, len);
             core::slice::from_raw_parts_mut(p, len)

--- a/src/phbl.rs
+++ b/src/phbl.rs
@@ -117,40 +117,40 @@ fn cpio_addr() -> mem::V4KA {
 
 /// Returns the address of the start of the loader text segment.
 fn text_addr() -> mem::V4KA {
-    mem::V4KA::new(unsafe { __sloader.as_ptr() as usize })
+    mem::V4KA::new(unsafe { __sloader.as_ptr().addr() })
 }
 
 /// Returns the address of the start of the loader read-only
 /// data segment.
 fn rodata_addr() -> mem::V4KA {
-    mem::V4KA::new(unsafe { etext.as_ptr() as usize })
+    mem::V4KA::new(unsafe { etext.as_ptr().addr() })
 }
 
 /// Returns the address of the start of the loader read/write
 /// data segment.
 fn data_addr() -> mem::V4KA {
-    mem::V4KA::new(unsafe { erodata.as_ptr() as usize })
+    mem::V4KA::new(unsafe { erodata.as_ptr().addr() })
 }
 
 /// Returns the address of the start of the loader BSS segment.
 fn bss_addr() -> mem::V4KA {
-    mem::V4KA::new(unsafe { edata.as_ptr() as usize })
+    mem::V4KA::new(unsafe { edata.as_ptr().addr() })
 }
 
 /// Returns the address of the end of the loader BSS.
 fn end_addr() -> mem::V4KA {
-    mem::V4KA::new(unsafe { end.as_ptr() as usize })
+    mem::V4KA::new(unsafe { end.as_ptr().addr() })
 }
 
 /// Returns the address of end of the loader memory image,
 /// including the boot block and reset vector.
 fn eaddr() -> mem::V4KA {
-    mem::V4KA::new(unsafe { __eloader.as_ptr() as usize })
+    mem::V4KA::new(unsafe { __eloader.as_ptr().addr() })
 }
 
 /// Returns the address of the boot block.
 fn bootblock_addr() -> mem::V4KA {
-    mem::V4KA::new(unsafe { bootblock.as_ptr() as usize })
+    mem::V4KA::new(unsafe { bootblock.as_ptr().addr() })
 }
 
 /// Returns the address of the start of the MMIO region
@@ -172,8 +172,9 @@ pub(crate) fn ramdisk_region_init_mut() -> &'static mut [u8] {
     let text = text_addr().addr();
     const PHBL_MIN: usize = 2 * mem::GIB - 256 * mem::MIB;
     assert!(PHBL_MIN < cpio && cpio < text);
+    const PHBL_BASE: *mut u8 = core::ptr::invalid_mut(PHBL_MIN);
     let len = text - cpio;
-    let cpio = cpio as *mut u8;
+    let cpio = PHBL_BASE.with_addr(cpio);
     unsafe {
         core::ptr::write_bytes(cpio, 0, len);
         core::slice::from_raw_parts_mut(cpio, len)

--- a/src/uart.rs
+++ b/src/uart.rs
@@ -438,7 +438,8 @@ impl Device {
     }
 
     fn reset<'a>(self) -> &'a mut ConfigMmio {
-        let uart = unsafe { &mut *(self.addr() as *mut ConfigMmio) };
+        const NULL: *mut ConfigMmio = core::ptr::null_mut();
+        let uart = unsafe { &mut *NULL.with_addr(self.addr()) };
         unsafe {
             ptr::write_volatile(
                 &mut uart.srr,
@@ -466,12 +467,14 @@ impl Uart {
     }
 
     fn write_mmio_mut(&mut self) -> &mut MmioWrite {
-        let regs = self.0.addr() as *mut MmioWrite;
+        const NULL: *mut MmioWrite = core::ptr::null_mut();
+        let regs = NULL.with_addr(self.0.addr());
         unsafe { &mut *regs }
     }
 
     fn read_mmio_mut(&mut self) -> &mut MmioRead {
-        let regs = self.0.addr() as *mut MmioRead;
+        const NULL: *mut MmioRead = core::ptr::null_mut();
+        let regs = NULL.with_addr(self.0.addr());
         unsafe { &mut *regs }
     }
 


### PR DESCRIPTION
This is the first cut of getting `phbl` working with the strict provenance infrastructure:
https://github.com/rust-lang/rust/issues/95228

This found a bug: we were using `then_some` to return pointers to page tables that were not necessarily present; the fix is to use `then` and a closure.  Lambda combinators for the win!

Signed-off-by: Dan Cross <cross@oxidecomputer.com>