### PR TITLE
output: emit a blank line on entry

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,7 @@ type Result<T> = core::result::Result<T, &'static str>;
 /// The main entry point, called from assembler.
 #[no_mangle]
 pub(crate) extern "C" fn entry(config: &mut phbl::Config) {
+    println!();
     println!("Oxide Pico Host Boot Loader");
     println!("{config:#x?}");
     let ramdisk = expand_ramdisk();


### PR DESCRIPTION
At Josh's suggestion, emit a blank line to the UART at startup, to get out of the soup of potential UART floating goo.

Signed-off-by: Dan Cross <cross@oxidecomputer.com>