### PR TITLE
ci: add a miri target.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,13 @@ jobs:
       - name: Run phbl tests
         run: cargo xtask test
 
+  miri:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run phbl miri tests
+        run: cargo miri test
+
   format:
     runs-on: ubuntu-latest
     steps:

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly"
-components = [ "rustfmt", "rust-src", "llvm-tools-preview", "clippy" ]
+channel = "nightly-2022-09-15"
+components = [ "rustfmt", "rust-src", "llvm-tools-preview", "clippy", "miri" ]


### PR DESCRIPTION
Now that miri is working with strict provenance,
add a CI target to run it on push.

Signed-off-by: Dan Cross <cross@oxidecomputer.com>