### PR TITLE
Don't try to forge provenance from a nil pointer

### DIFF
--- a/src/fakes.rs
+++ b/src/fakes.rs
@@ -31,6 +31,9 @@ static bootblock: usize = 65536 + 4096;
 static __eloader: usize = 65536 + 8192;
 /// Defined in assembly.
 #[no_mangle]
+static MMIO_BASE: usize = 65536 + 16384;
+/// Defined in assembly.
+#[no_mangle]
 static STACK_SIZE: u64 = 8 * 4096;
 /// Defined in assembly.
 #[no_mangle]

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -129,8 +129,7 @@ fn load_segment(
             page_table
                 .map_region(region.clone(), mem::Attrs::new_data(), pa)
                 .expect("mapped region {region:#x?} read-write");
-            const NULL: *mut u8 = core::ptr::null_mut();
-            let p = NULL.with_addr(start.addr());
+            let p = page_table.try_with_addr(start.addr()).unwrap();
             let len = end.addr() - start.addr();
             core::ptr::write_bytes(p, 0, len);
             core::slice::from_raw_parts_mut(p, len)

--- a/src/uart.rs
+++ b/src/uart.rs
@@ -441,8 +441,8 @@ impl Device {
     }
 
     fn reset<'a>(self) -> &'a mut ConfigMmio {
-        const NULL: *mut ConfigMmio = core::ptr::null_mut();
-        let uart = unsafe { &mut *NULL.with_addr(self.addr()) };
+        let regs = core::ptr::from_exposed_addr_mut::<ConfigMmio>(self.addr());
+        let uart = unsafe { &mut *regs };
         unsafe {
             ptr::write_volatile(
                 &mut uart.srr,
@@ -470,8 +470,7 @@ impl Uart {
     }
 
     fn write_mmio_mut(&mut self) -> &mut MmioWrite {
-        const NULL: *mut MmioWrite = core::ptr::null_mut();
-        let regs = NULL.with_addr(self.0.addr());
+        let regs = core::ptr::from_exposed_addr_mut::<MmioWrite>(self.0.addr());
         unsafe { &mut *regs }
     }
 
@@ -480,8 +479,7 @@ impl Uart {
     // it is mutually exclusive with a write MMIO structure,
     // as the two share the same register space.
     fn read_mmio_mut(&mut self) -> &mut MmioRead {
-        const NULL: *mut MmioRead = core::ptr::null_mut();
-        let regs = NULL.with_addr(self.0.addr());
+        let regs = core::ptr::from_exposed_addr_mut::<MmioRead>(self.0.addr());
         unsafe { &mut *regs }
     }
 


### PR DESCRIPTION
As pointed out by Ben Kimock in issue #22, NULL carries no provenance, and attempting to forge a dereferenceable pointer from NULL is UB.

Remove that paradigm from `phbl` by applying different techniques:

1. Where we just need a pointer to get its address and nothing else, `core::ptr::invalid` serves nicely.
2. When we want to get a pointer from a freshly-mapped address, as when loading the kernel, ask the page table to use its provenance to create the pointer.  Indeed, the page table can even validate that it properly maps the given address.
3. For early UART initialization, introduce an `MMIO_BASE` symbol in assembly language that we can leverage to get a provenance-providing pointer.

I believe these changes together address address the UB issue, but would appreciate @saethlin's input.  Thank you again!

Fixes: #22
Signed-off-by: Dan Cross <cross@oxidecomputer.com>