### PR TITLE
Update deps, rust; address uncovered lints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,9 +86,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e82dad04139b71a90c080c8463fe0dc7902db5192d939bd0950f074d014339e1"
+checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
 
 [[package]]
 name = "phbl"
@@ -113,9 +113,9 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.44"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bd7356a8122b6c4a24a82b278680c73357984ca2fc79a0f9fa6dea7dced7c58"
+checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
 dependencies = [
  "unicode-ident",
 ]
@@ -172,9 +172,9 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "syn"
-version = "1.0.101"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e90cde112c4b9690b8cbe810cba9ddd8bc1d7472e2cae317b69e9438c1cba7d2"
+checksum = "a864042229133ada95abf3b54fdc62ef5ccabe9515b64717bcb9a1919e59445d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -183,9 +183,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcc811dc4066ac62f84f11307873c4850cb653bfa9b1719cee2bd2204a4bc5dd"
+checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
 
 [[package]]
 name = "x86"

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2022-09-26"
+channel = "nightly-2022-11-03"
 components = [ "rustfmt", "rust-src", "llvm-tools-preview", "clippy", "miri" ]

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -106,7 +106,7 @@ fn load_segment(
     section: &ProgramHeader,
     bytes: &[u8],
 ) -> Result<()> {
-    let pa = section.p_paddr as u64;
+    let pa = section.p_paddr;
     if pa % mem::P4KA::ALIGN != 0 {
         return Err("Program section is not physically 4KiB aligned");
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 #![feature(allocator_api, alloc_error_handler, new_uninit)]
-#![feature(asm_const, asm_sym)]
+#![feature(asm_const)]
 #![feature(naked_functions)]
 #![feature(pointer_is_aligned)]
 #![feature(strict_provenance)]

--- a/src/mmu.rs
+++ b/src/mmu.rs
@@ -860,7 +860,7 @@ impl PageTable {
                 && (pa as usize) % PFN1G::SIZE == 0
             {
                 unsafe {
-                    self.map(Page1G::new(start), PFN1G::new(pa as u64), attrs);
+                    self.map(Page1G::new(start), PFN1G::new(pa), attrs);
                 }
                 PFN1G::SIZE
             } else if end.wrapping_sub(start) >= PFN2M::SIZE
@@ -868,7 +868,7 @@ impl PageTable {
                 && (pa as usize) % PFN2M::SIZE == 0
             {
                 unsafe {
-                    self.map(Page2M::new(start), PFN2M::new(pa as u64), attrs);
+                    self.map(Page2M::new(start), PFN2M::new(pa), attrs);
                 }
                 PFN2M::SIZE
             } else if end.wrapping_sub(start) >= PFN4K::SIZE
@@ -876,7 +876,7 @@ impl PageTable {
                 && (pa as usize) % PFN4K::SIZE == 0
             {
                 unsafe {
-                    self.map(Page4K::new(start), PFN4K::new(pa as u64), attrs);
+                    self.map(Page4K::new(start), PFN4K::new(pa), attrs);
                 }
                 PFN4K::SIZE
             } else {

--- a/xtask/Cargo.lock
+++ b/xtask/Cargo.lock
@@ -27,9 +27,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "clap"
-version = "3.2.22"
+version = "3.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86447ad904c7fb335a790c9d7fe3d0d971dc523b8ccd1561a520de9a85302750"
+checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
 dependencies = [
  "atty",
  "bitflags",
@@ -88,15 +88,15 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.133"
+version = "0.2.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0f80d65747a3e43d1596c7c5492d95d5edddaabd45a7fcdb02b95f644164966"
+checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
 
 [[package]]
 name = "once_cell"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e82dad04139b71a90c080c8463fe0dc7902db5192d939bd0950f074d014339e1"
+checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
 
 [[package]]
 name = "os_pipe"
@@ -110,9 +110,9 @@ dependencies = [
 
 [[package]]
 name = "os_str_bytes"
-version = "6.3.0"
+version = "6.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ff7415e9ae3fff1225851df9e0d9e4e5479f947619774677a63572e55e80eff"
+checksum = "3baf96e39c5359d2eb0dd6ccb42c62b91d9678aa68160d261b9e0ccbf9e9dea9"
 
 [[package]]
 name = "shared_child"
@@ -141,9 +141,9 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.15.1"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "949517c0cf1bf4ee812e2e07e08ab448e3ae0d23472aee8a06c985f0c8815b16"
+checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "winapi"


### PR DESCRIPTION
Update dependencies via `cargo update` and update
rust to the latest (as of this commit) nightly.

Doing this uncovers a few new lints; address those (they're trivial).  Also, `asm_sym` is now stable
on this nightly, so remove it from the list of
`#![feature(...)]` flags.

Signed-off-by: Dan Cross <cross@oxidecomputer.com>