### PR TITLE
Fix missing `repr(C)` in UART types

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2022-11-03"
+channel = "nightly-2023-02-03"
 components = [ "rustfmt", "rust-src", "llvm-tools", "clippy", "miri" ]

--- a/src/uart.rs
+++ b/src/uart.rs
@@ -254,6 +254,7 @@ const UART_MMIO_BASE_ADDR: usize = 0xFEDC_9000;
 /// Describes the UART registers when the divisor latch is set
 /// in the line control register.  This is the state in that
 /// that the UART is in after calling Device::reset.
+#[repr(C)]
 struct ConfigMmio {
     dll: Dll,
     dlh: Dlh,
@@ -371,6 +372,7 @@ struct MmioRead {
 const_assert_eq!(core::mem::size_of::<MmioRead>(), 256);
 
 /// Describes the UART registers for a write
+#[repr(C)]
 struct MmioWrite {
     thr: Thr,         // 0x00
     _ier: u32,        // 0x04


### PR DESCRIPTION
Add `repr(C)` to a few structs that mirror hardware registers; Rust was reordering these in ways that prevented boot.

I could have sworn I fixed this already, but apparently not. I wonder if I flubbed a commit.  :-/

Signed-off-by: Dan Cross <cross@oxidecomputer.com>