### PR TITLE
linker: omit BSS from loadable segments

### DIFF
--- a/src/fakes.rs
+++ b/src/fakes.rs
@@ -19,7 +19,10 @@ static erodata: usize = 16384;
 static edata: usize = 32768;
 /// Linker symbol.
 #[no_mangle]
-static end: usize = 65536;
+static sbss: usize = 32768 + 16384;
+/// Linker symbol.
+#[no_mangle]
+static ebss: usize = 65536;
 /// Defined in assembly.
 #[no_mangle]
 static stack: usize = 65536;

--- a/src/phbl.ld
+++ b/src/phbl.ld
@@ -10,38 +10,39 @@ SECTIONS {
 	.start bootblock : {
 		FILL(0xffffffff);
 		*(.start)
-	}
+	} :srodata
 	.start.rodata ALIGN(64) : {
 		*(.start.rodata)
-	}
+	} :srodata
 	.reset resetaddr : {
 		FILL(0xffffffff);
 		*(.reset)
 		__eloader = ALIGN(65536);
-	}
+	} :srodata
 
-	.bss ((ADDR(.start) - bsssize) & ~0xFFF) : {
-		*(.bss* COMMON)
-		end = ALIGN(4096);
-	}
-
-	.data ((ADDR(.bss) - datasize) & ~0xFFF) : {
+	.data ((ADDR(.start) - datasize) & ~0xFFF) : {
 		FILL(0xffffffff);
 		*(.data*)
 		edata = ALIGN(4096);
-	}
+	} :data
 
 	.rodata ((ADDR(.data) - rodatasize) & ~0xFFF): {
 		FILL(0xffffffff);
 		*(.rodata*)
 		erodata = ALIGN(4096);
-	}
+	} :rodata
 
 	.text ((ADDR(.rodata) - textsize) & ~0xFFF) : {
 		__sloader = .;
 		FILL(0xffffffff);
 		*(.text*)
 		etext = ALIGN(4096);
+	} :text
+
+	.bss ((ADDR(.text) - bsssize) & ~0xFFF) (NOLOAD) : {
+		sbss = .;
+		*(.bss* COMMON)
+		ebss = ALIGN(4096);
 	}
 
 	textsize = SIZEOF(.text);
@@ -54,4 +55,11 @@ SECTIONS {
 	/DISCARD/ : {
 		*(.got* .comment* .note* .eh_frame*)
 	}
+}
+
+PHDRS {
+	text	PT_LOAD;
+	rodata	PT_LOAD;
+	data	PT_LOAD;
+	srodata	PT_LOAD;
 }

--- a/src/start.S
+++ b/src/start.S
@@ -205,8 +205,8 @@ start64:
 	movw	%ax, %ss
 
 	// Zero out the BSS.
-	movq	$end, %rcx
-	movq	$edata, %rdi
+	movq	$ebss, %rcx
+	movq	$sbss, %rdi
 	xorl	%eax, %eax
 	subq	%rdi, %rcx
 	rep; stosb


### PR DESCRIPTION
It turns out that, when written into a ROM image, the BSS was expanded into actual zeroed bytes copied that were into flash (the BIOS loader on the PSP doesn't do any interpretation of the payload; it just copies bytes, so it kind of has to do this).  This took up unnecessary space in flash.

But we already zero the BSS and map it explicitly, so just relocate it before the text segment and mark it NOLOAD in the linker script (and make some trivial corresponding adjustments in the mapping code).  Et voila, we save a few megabytes of flash.