### PR TITLE
allocator: align arena on 4KiB boundaries

### DIFF
--- a/src/allocator.rs
+++ b/src/allocator.rs
@@ -23,6 +23,7 @@ use core::sync::atomic::{AtomicUsize, Ordering};
 /// A simple bump allocator for use as a global allocator
 /// (for Goblin) as well as implementing the specific
 /// allocator interface (for page tables).
+#[repr(C, align(4096))]
 pub(crate) struct BumpAlloc<const SIZE: usize> {
     heap: UnsafeCell<[u8; SIZE]>,
     offset: AtomicUsize,

--- a/src/mmu.rs
+++ b/src/mmu.rs
@@ -1226,6 +1226,9 @@ mod arena {
     // See RFD215 for details.
     const_assert!(PAGE_ARENA_SIZE > 16 * PAGE_SIZE);
 
+    static mut PAGE_ALLOCATOR: BumpAlloc<{ PAGE_ARENA_SIZE }> =
+        BumpAlloc::new([0; PAGE_ARENA_SIZE]);
+
     /// An allocator specialized for MMU page allocations.
     ///
     /// # Safety
@@ -1251,12 +1254,6 @@ mod arena {
             Ok(ptr as *mut T)
         }
     }
-
-    #[repr(C, align(4096))]
-    struct PageArena([u8; PAGE_ARENA_SIZE]);
-    static mut PAGES: PageArena = PageArena([0; PAGE_ARENA_SIZE]);
-    static mut PAGE_ALLOCATOR: BumpAlloc<{ PAGE_ARENA_SIZE }> =
-        BumpAlloc::new(unsafe { PAGES.0 });
 
     unsafe impl Allocator for TableAlloc {
         fn allocate(

--- a/src/start.S
+++ b/src/start.S
@@ -70,7 +70,7 @@ STACK_SIZE =		8 * PAGE_SIZE
 // clear after RESET, but it never hurts to be explicit,
 // so we clear both and then simply jump to the 16-bit
 // startup code.
-.section ".reset", "ax", @progbits
+.section ".reset", "a", @progbits
 .globl reset
 reset:
 	cli
@@ -86,7 +86,7 @@ reset:
 // latch, we do not have to deal with it.  Similarly,
 // we do not mask out the PIC, as there is no PIC on
 // Oxide machines.
-.section ".start", "ax", @progbits
+.section ".start", "a", @progbits
 .balign PAGE_SIZE
 .code16
 start:


### PR DESCRIPTION
I noticed when moving the BSS around that the page allocator for building page tables (e.g., for mapping the kernel) was inheriting a region that was not 4KiB aligned.  The simplest fix was just to constrain the allocator itself to be aligned on a 4K boundary, and there was no reason not to do this.