### PR TITLE
SP5: Initialize IO mux for UART0 pins

### DIFF
--- a/src/iomux.rs
+++ b/src/iomux.rs
@@ -1,0 +1,70 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/// Supported pin functions.
+#[derive(Clone, Copy)]
+#[repr(u8)]
+enum GpioX {
+    F0 = 0b00,
+    _F1 = 0b01,
+    _F2 = 0b10,
+    _F3 = 0b11,
+}
+
+/// Initializes the IO mux so that pins for UART 0 are mapped to
+/// UART functions.  In some cases, the values observed are
+/// different from the documented reset values, so we force them
+/// to our desired settings.
+///
+/// # Safety
+/// The caller must ensure that the IO mux MMIO region is in the
+/// current address space.
+pub unsafe fn init() {
+    if let Some(settings) = mux_settings() {
+        const GPIO_BASE_ADDR: usize = 0xFED8_0000;
+        const IOMUX_BASE_ADDR: usize = GPIO_BASE_ADDR + 0x0D00;
+        let iomux = IOMUX_BASE_ADDR as *mut u8;
+        for (pin, function) in settings.iter() {
+            unsafe {
+                core::ptr::write_volatile(iomux.offset(*pin), *function as u8);
+            }
+        }
+    }
+}
+
+/// Returns the correct IO mux settings for the current system,
+/// if any.
+fn mux_settings() -> Option<&'static [(isize, GpioX)]> {
+    const SP5: u32 = 4;
+
+    match cpuinfo()? {
+        // We really ought to explicitly check socket type
+        // for the earlier processor models here.
+        (0x17, 0x00..=0x0f, 0x0..=0xf, _) | // Naples
+        (0x17, 0x30..=0x3f, 0x0..=0xf, _) | // Rome
+        (0x19, 0x00..=0x0f, 0x0..=0xf, _) | // Milan
+        (0x19, 0x10..=0x1f, 0x0..=0xf, Some(SP5)) | // Genoa
+        (0x19, 0xa0..=0xaf, 0x0..=0xf, Some(SP5)) | // Bergamo and Sienna
+        (0x1a, 0x00..=0x1f, 0x0..=0xf, Some(SP5)) => { // Turin
+            Some(&[
+                (135, GpioX::F0),
+                (136, GpioX::F0),
+                (137, GpioX::F0),
+                (138, GpioX::F0),
+            ])
+        },
+        _ => None,
+    }
+}
+
+/// Returns information about the current processor and its
+/// package.
+fn cpuinfo() -> Option<(u8, u8, u8, Option<u32>)> {
+    let cpuid = x86::cpuid::CpuId::new();
+    let features = cpuid.get_feature_info()?;
+    let family = features.family_id();
+    let ext = cpuid.get_extended_processor_and_feature_identifiers()?;
+    let pkg_type = (family > 0x10).then_some(ext.pkg_type());
+    Some((family, features.model_id(), features.stepping_id(), pkg_type))
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@
 
 mod allocator;
 mod idt;
+mod iomux;
 mod loader;
 mod mem;
 mod mmu;

--- a/src/phbl.rs
+++ b/src/phbl.rs
@@ -39,6 +39,7 @@
 extern crate alloc;
 
 use crate::idt;
+use crate::iomux;
 use crate::mem;
 use crate::mmu;
 use crate::uart::{self, Uart};
@@ -82,7 +83,10 @@ pub(crate) unsafe extern "C" fn init(bist: u32) -> &'static mut Config {
     if INITED.swap(true, Ordering::AcqRel) {
         panic!("Init already called");
     }
-    uart::init();
+    unsafe {
+        iomux::init();
+        uart::init();
+    }
     idt::init();
     if bist != 0 {
         panic!("bist failed: {bist:#x}");

--- a/src/uart.rs
+++ b/src/uart.rs
@@ -523,7 +523,7 @@ pub fn cons() -> Uart {
 /// # Safety
 /// The caller must ensure that MMIO space for the UARTs is
 /// properly mapped before calling this.
-pub fn init() {
+pub unsafe fn init() {
     if !UART0_INITED.swap(true, Ordering::AcqRel) {
         Device::Uart0.init(Rate::B3M, Datas::Bits8, Stops::Stop1, Parity::No);
     }


### PR DESCRIPTION
We have observed that, for the pins connected to UART0, the pin mux on e.g. Genoa has values that differ from the documented reset values, causing those pins to be used as e.g. GPIOs.  Set them explicitly so we have console output.