### PR TITLE
kernel entry: clear argument registers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,10 +3,10 @@
 version = 3
 
 [[package]]
-name = "adler"
-version = "1.0.2"
+name = "adler2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
 name = "bit_field"
@@ -68,11 +68,11 @@ checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.4"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
+checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
 dependencies = [
- "adler",
+ "adler2",
 ]
 
 [[package]]
@@ -178,9 +178,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.12"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
 
 [[package]]
 name = "x86"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ goblin = { version = "0.8", default-features = false, features = [
     "elf32",
     "alloc",
 ] }
-miniz_oxide = "0.7"
+miniz_oxide = "0.8"
 seq-macro = "0.3"
 static_assertions = "1.1"
 x86 = "0.52"

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2024-09-04"
+channel = "nightly-2024-09-19"
 components = [ "rustfmt", "rust-src", "llvm-tools", "clippy", "miri" ]

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,10 +33,8 @@ pub(crate) extern "C" fn entry(config: &mut phbl::Config) {
     let kernel = find_kernel(ramdisk);
     let entry =
         loader::load(&mut config.page_table, kernel).expect("loaded kernel");
-    println!("jumping to kernel entry at {:#x?}", entry as *const fn());
-    unsafe {
-        entry(ramdisk.as_ptr().addr() as u64, ramdisk.len(), 0);
-    }
+    println!("jumping into kernel...");
+    entry(ramdisk.as_ptr().addr() as u64, ramdisk.len());
     panic!("main returning");
 }
 

--- a/xtask/Cargo.lock
+++ b/xtask/Cargo.lock
@@ -190,9 +190,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.12"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
 
 [[package]]
 name = "utf8parse"


### PR DESCRIPTION
At one point, we experimented with passing additional arguments into the Unix kernel from phbl.  While we ultimately backed away from that design, something that has long bothered me about it is that doing so would require a flag day to coordinate between the kernel and loader, as `phbl` did not take care to clear argument registers when invoking the kernel's entry point, so a kernel expecting a new argument must be paired with an updated loader.  While in practice this isn't an issue, since we ship the operating system image inside of the loader itself, it does require another coordination point between helios and phbl, and aesthetically it wasn't pleasing.  In order to future-proof things, phbl really ought to clear the argument registers its not using on kernel entry.

Fortunately, this is relatively easy to do: when we transmute the ELF entry point value into a variable of function type, we just say it's a function that takes 6 values (the ABI specifies that the first six arguments are passed in registers), and we pass explicit 0's for anything we don't actually use.

In doing this, I did allow myself an aesthetic conceit in that disliked calling the function with all six arguments after finding the entry point; the workaround for this is to wrap its invocation in a closure that's returned from the loader.  The downside is that the `unsafe` block in `main` is gone, and we're no longer printing the address of the entry point, but those seem minor.