### PR TITLE
updates: rust, dependencies, segmentation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,9 +62,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.26"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30bde2b3dc3671ae49d8e2e9f044c7c005836e7a023ee57cffa25ab82764bb9e"
+checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "miniz_oxide"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2025-03-10"
-components = [ "rustfmt", "rust-src", "llvm-tools", "clippy", "miri" ]
+channel = "nightly-2025-04-02"
+components = [ "rustfmt", "rust-src", "llvm-tools", "clippy", "miri", "rust-analyzer" ]

--- a/src/iomux.rs
+++ b/src/iomux.rs
@@ -49,10 +49,10 @@ fn mux_settings() -> Option<&'static [(isize, GpioX)]> {
         (0x19, 0xa0..=0xaf, 0x0..=0xf, Some(SP5)) | // Bergamo and Sienna
         (0x1a, 0x00..=0x1f, 0x0..=0xf, Some(SP5)) => { // Turin
             Some(&[
-                (135, GpioX::F0),
-                (136, GpioX::F0),
-                (137, GpioX::F0),
-                (138, GpioX::F0),
+                (135, GpioX::F0),  // UART0 CTS
+                (136, GpioX::F0),  // UART0 RXD
+                (137, GpioX::F0),  // UART0 RTS
+                (138, GpioX::F0),  // UART0 TXD
             ])
         },
         _ => None,

--- a/src/start.S
+++ b/src/start.S
@@ -43,8 +43,8 @@ GDT_CODE32 =		2 << 3
 GDT_DATA32 =		3 << 3
 .globl GDT_CODE64
 
-SEG_READ =		1 << 41
-SEG_WRITE =		1 << 42	// Only for data, not code segments.
+SEG_CODE_RO =		1 << 41	// Only for code, not data segments.
+SEG_DATA_RW =		1 << 41	// Only for data, not code segments.
 SEG_DATA =		0 << 43
 SEG_CODE =		1 << 43	// Code segments are read-only.
 SEG_PRESENT =		1 << 47
@@ -180,11 +180,11 @@ gdt:
 	// 0x0: Null segment.
 	.quad	0
 	// 0x8: 64-bit code segment.
-	.quad	(SEG_PRESENT + SEG_READ + SEG_CODE + SEG_LONG + SEG_MUSTBE1)
+	.quad	(SEG_PRESENT + SEG_CODE_RO + SEG_CODE + SEG_LONG + SEG_MUSTBE1)
 	// 0x10: 32-bit code segment.
-	.quad	(SEG_PRESENT + SEG_READ + SEG_CODE + SEG32 + SEG_MUSTBE1)
+	.quad	(SEG_PRESENT + SEG_CODE_RO + SEG_CODE + SEG32 + SEG_MUSTBE1)
 	// 0x18: 32-bit data segment.
-	.quad	(SEG_PRESENT + SEG_READ + SEG_WRITE + SEG32 + SEG_MUSTBE1)
+	.quad	(SEG_PRESENT + SEG_DATA_RW + SEG_DATA + SEG32 + SEG_MUSTBE1)
 egdt:
 
 .skip 6

--- a/xtask/Cargo.lock
+++ b/xtask/Cargo.lock
@@ -54,9 +54,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.32"
+version = "4.5.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6088f3ae8c3608d19260cd7445411865a485688711b78b5be70d78cd96136f83"
+checksum = "d8aa86934b44c19c50f87cc2790e19f54f7a67aedb64101c2e1a2e5ecfb73944"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -64,9 +64,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.32"
+version = "4.5.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22a7ef7f676155edfb82daa97f99441f3ebf4a58d5e32f295a56259f1b6facc8"
+checksum = "2414dbb2dd0695280da6ea9261e327479e9d37b0630f6b53ba2a11c60c679fd9"
 dependencies = [
  "anstream",
  "anstyle",
@@ -130,9 +130,9 @@ checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
 
 [[package]]
 name = "once_cell"
-version = "1.21.0"
+version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cde51589ab56b20a6f686b2c68f7a0bd6add753d697abf720d63f8db3ab7b1ad"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "os_pipe"


### PR DESCRIPTION
This change updates Rust and dependencies, but also fixes a bug, where the 32-bit data segment was not writeable.  While this did not affect anything in practice (we don't write to the data segment in 32-bit mode), it was incorrect.  Fix it.