### PR TITLE
update: trivial update rust

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2025-04-21"
+channel = "nightly-2025-04-22"
 components = [ "rustfmt", "rust-src", "llvm-tools", "clippy", "miri", "rust-analyzer" ]

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,6 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 #![feature(allocator_api)]
-#![feature(naked_functions)]
 #![feature(sync_unsafe_cell)]
 #![cfg_attr(not(any(test, clippy)), no_std)]
 #![cfg_attr(not(test), no_main)]


### PR DESCRIPTION
This is a trivial addendum to the last change, updating the compiler version to today's nightly and removing the `naked_functions` feature, as that is now stable.

I had meant to wrap this into the previous change, but evidently my command of the `git` command is not very commanding.